### PR TITLE
【サーバサイド】商品削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_params, only: :create
   before_action :set_category
-  before_action :set_item, only: [:show, :edit]
+  before_action :set_item, only: [:show, :edit, :destroy]
 
   def index
     @items = Item.all.where(status_id: '1').order(created_at: :desc)
@@ -30,6 +30,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   def list

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,9 +33,14 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to root_path
+  if @item.seller_id == current_user.id
+    if @item.destroy
+      redirect_to root_path, notice: "削除が完了しました"
+    else
+      redirect_to root_path, alert: "削除に失敗しました"
+    end
   end
+end
 
   def list
     @items = Item.where(status_id: '1').order(created_at: :desc)

--- a/app/views/items/_detail_contents.html.haml
+++ b/app/views/items/_detail_contents.html.haml
@@ -74,7 +74,7 @@
     - if user_signed_in? && current_user.id == @item.seller_id
       .item-edit
         = link_to "商品編集", edit_item_path, class: "edit"
-        = link_to "商品削除", "#", class: "delete"
+        = link_to "商品削除", item_path(@item.id), method: :delete, data: {confirm: "本当に削除しますか？"}
 
     -else
       .purchase


### PR DESCRIPTION
# What
商品詳細ページから商品を削除する

# Why
ログインしたユーザーにのみ削除処理を実行できる

商品一覧
[![Image from Gyazo](https://i.gyazo.com/e27f239c8671860d0cbe0cf33f3e7cb2.png)](https://gyazo.com/e27f239c8671860d0cbe0cf33f3e7cb2)

削除ボタンを押した際、確認ダイアログメッセージを表示
[![Image from Gyazo](https://i.gyazo.com/2a77ae65535b4b58c5bb2c8071eac589.png)](https://gyazo.com/2a77ae65535b4b58c5bb2c8071eac589)

商品を削除した後自動的にトップページに戻り、商品一覧(内部データ)から該当商品を削除
[![Image from Gyazo](https://i.gyazo.com/b371ac8bb32675ffce2499c7d33b9cce.png)](https://gyazo.com/b371ac8bb32675ffce2499c7d33b9cce)