### PR TITLE
[バグ修正]商品詳細から編集への遷移、トップページから商品詳細への遷移

### DIFF
--- a/app/views/items/_detail_contents.html.haml
+++ b/app/views/items/_detail_contents.html.haml
@@ -73,7 +73,7 @@
 
     - if user_signed_in? && current_user.id == @item.seller_id
       .item-edit
-        = link_to "商品編集", edit_item_path, class: "edit"
+        = link_to "商品編集", edit_item_path, class: "edit", data:{"turbolinks" => false}
         = link_to "商品削除", item_path(@item.id), method: :delete, data: {confirm: "本当に削除しますか？"}
 
     -else

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -87,7 +87,7 @@
       .product__lists
         - @items[0..2].each do |item|
           =link_to item_path(item.id) do
-            =image_tag ("#{item.images.first.image}"), class: "product__list--img"   
+            =image_tag ("#{item.images.first.image}"), class: "product__list--img"
             .product__list--body
               %h3= item.name
               .details
@@ -103,8 +103,8 @@
         .product__head
         .product__lists
           - @items[3..5].each do |item|
-            =link_to detail_items_path do
-              =image_tag ("#{item.images.first.image}"), class: "product__list--img" 
+            =link_to item_path(item.id) do
+              =image_tag ("#{item.images.first.image}"), class: "product__list--img"
               .product__list--body
                 %h3= item.name
                 .details


### PR DESCRIPTION
# What
・商品詳細から商品編集への遷移した際、画像が表示されていなかった不具合の修正
・トップページ(商品一覧)に表示されている4件目以降の商品詳細画面へのリンクの不具合の修正

# Why
・動作確認で見つかった2点の不具合修正のため

【商品詳細から商品編集への遷移】
https://gyazo.com/476bf979a101d43636a8cb3712811997

【商品一覧から詳細への遷移】
https://gyazo.com/2b518f9e49ce2960fe1801aaf7eaa5df